### PR TITLE
Preserve caller directory during JVM startup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,10 @@ jobs:
         os: [ windows-latest, macos-latest, ubuntu-latest ]
     steps:
       - uses: actions/checkout@v4
+      - name: Check formatting
+        run: cargo fmt --check
+      - name: Test launcher behavior
+        run: cargo test --all-features
       - name: Build Windows
         if: matrix.os == 'windows-latest'
         run: |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ A JVM starter in Rust
 
 In addition to launching the JVM, it hints Windows systems with hybrid GPU setups ([NVIDIA Optimus](https://docs.nvidia.com/gameworks/content/technologies/desktop/optimus.htm), [AMD PowerXpress](https://gpuopen.com/learn/amdpowerxpressrequesthighperformance/)) to use the discrete GPU.
 
+Roast may be launched from any Unicode-representable working directory. It initializes the JVM from
+the installation directory so relative AOT classpaths remain valid, then restores the caller
+directory before Java application code runs. Both the native process working directory and Java's
+`user.dir` therefore match the directory from which Roast was invoked. The launcher reserves
+`-Duser.dir` to enforce this contract and overrides any value supplied in `vmArgs`.
+
 ## API
 
 `roast` will look for the following in its containing folder

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,0 +1,78 @@
+use std::{
+    env, io,
+    path::{Path, PathBuf},
+};
+
+#[cfg(target_os = "windows")]
+const CLASS_PATH_DELIMITER: &str = ";";
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+const CLASS_PATH_DELIMITER: &str = ":";
+
+pub(crate) struct WorkingDirectoryGuard {
+    original: PathBuf,
+    restored: bool,
+}
+
+impl WorkingDirectoryGuard {
+    pub(crate) fn enter(path: &Path) -> io::Result<Self> {
+        let original = env::current_dir()?;
+        env::set_current_dir(path)?;
+        Ok(Self {
+            original,
+            restored: false,
+        })
+    }
+
+    pub(crate) fn restore(&mut self) -> io::Result<()> {
+        if !self.restored {
+            env::set_current_dir(&self.original)?;
+            self.restored = true;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for WorkingDirectoryGuard {
+    fn drop(&mut self) {
+        if !self.restored {
+            let _ = env::set_current_dir(&self.original);
+        }
+    }
+}
+
+pub(crate) fn build_vm_options(
+    class_path: &[String],
+    vm_args: &[String],
+    application_working_directory: &Path,
+    use_zgc_if_supported: bool,
+) -> Vec<String> {
+    let mut options = vec![format!(
+        "-Djava.class.path={}",
+        class_path.join(CLASS_PATH_DELIMITER)
+    )];
+    options.extend(vm_args.iter().cloned());
+
+    if use_zgc_if_supported && is_zgc_supported() {
+        options.push("-XX:+UnlockExperimentalVMOptions".to_string());
+        options.push("-XX:+UseZGC".to_string());
+    }
+
+    let user_dir = application_working_directory
+        .to_str()
+        .expect("Caller working directory must be valid Unicode");
+    options.push(format!("-Duser.dir={user_dir}"));
+    options
+}
+
+#[cfg(target_os = "windows")]
+fn is_zgc_supported() -> bool {
+    // Windows 10 1803 is required for ZGC, see https://wiki.openjdk.java.net/display/zgc/Main#Main-SupportedPlatforms
+    // Windows 10 1803 is build 17134.
+    use windows_version::OsVersion;
+    OsVersion::current() >= OsVersion::new(10, 0, 0, 17134)
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn is_zgc_supported() -> bool {
+    true
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 use jni::{objects::JString, InitArgsBuilder, JNIVersion, JavaVM};
 use serde::Deserialize;
 use std::{
-    env, fs,
+    env, fs, io,
     path::{Path, PathBuf},
 };
 
@@ -48,8 +48,70 @@ const RUNTIME_LOCATION: [&str; 3] = ["runtime", "lib", "server"];
 
 const APP_FOLDER: &str = "app";
 
+struct WorkingDirectoryGuard {
+    original: PathBuf,
+    restored: bool,
+}
+
+struct JvmDirectories<'a> {
+    runtime: &'a Path,
+    bootstrap: &'a Path,
+    application: &'a Path,
+}
+
+impl WorkingDirectoryGuard {
+    fn enter(path: &Path) -> io::Result<Self> {
+        let original = env::current_dir()?;
+        env::set_current_dir(path)?;
+        Ok(Self {
+            original,
+            restored: false,
+        })
+    }
+
+    fn restore(&mut self) -> io::Result<()> {
+        if !self.restored {
+            env::set_current_dir(&self.original)?;
+            self.restored = true;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for WorkingDirectoryGuard {
+    fn drop(&mut self) {
+        if !self.restored {
+            let _ = env::set_current_dir(&self.original);
+        }
+    }
+}
+
+fn build_vm_options(
+    class_path: &[String],
+    vm_args: &[String],
+    application_working_directory: &Path,
+    use_zgc_if_supported: bool,
+) -> Vec<String> {
+    let mut options = vec![format!(
+        "-Djava.class.path={}",
+        class_path.join(CLASS_PATH_DELIMITER)
+    )];
+    options.extend(vm_args.iter().cloned());
+
+    if use_zgc_if_supported && is_zgc_supported() {
+        options.push("-XX:+UnlockExperimentalVMOptions".to_string());
+        options.push("-XX:+UseZGC".to_string());
+    }
+
+    let user_dir = application_working_directory
+        .to_str()
+        .expect("Caller working directory must be valid Unicode");
+    options.push(format!("-Duser.dir={user_dir}"));
+    options
+}
+
 fn start_jvm(
-    runtime_location: &Path,
+    directories: JvmDirectories<'_>,
     class_path: Vec<String>,
     main_class_name: &str,
     vm_args: Vec<String>,
@@ -57,31 +119,33 @@ fn start_jvm(
     use_zgc_if_supported: bool,
     use_main_as_context_class_loader: bool,
 ) {
-    let mut args_builder = InitArgsBuilder::new()
-        .version(JNIVersion::V8)
-        .option(format!(
-            "-Djava.class.path={}",
-            class_path.join(CLASS_PATH_DELIMITER)
-        ));
-
-    for arg in vm_args {
-        args_builder = args_builder.option(arg);
-    }
-
-    if use_zgc_if_supported && is_zgc_supported() {
-        args_builder = args_builder
-            .option("-XX:+UnlockExperimentalVMOptions")
-            .option("-XX:+UseZGC")
+    let mut args_builder = InitArgsBuilder::new().version(JNIVersion::V8);
+    for option in build_vm_options(
+        &class_path,
+        &vm_args,
+        directories.application,
+        use_zgc_if_supported,
+    ) {
+        args_builder = args_builder.option(option);
     }
 
     // Build the VM properties
     let jvm_args = args_builder.build().expect("Failed to buid VM properties");
 
-    // Create a new VM
+    // HotSpot validates relative AOT classpath entries against the native working directory used
+    // during VM creation. Bootstrap from the launcher directory, then restore the caller before
+    // any application class is loaded.
+    let mut working_directory = WorkingDirectoryGuard::enter(directories.bootstrap)
+        .expect("Failed to switch to launcher working directory");
     let jvm = JavaVM::with_libjvm(jvm_args, || {
-        Ok(runtime_location.join(java_locator::get_jvm_dyn_lib_file_name()))
+        Ok(directories
+            .runtime
+            .join(java_locator::get_jvm_dyn_lib_file_name()))
     })
     .expect("Failed to create a new JavaVM");
+    working_directory
+        .restore()
+        .expect("Failed to restore caller working directory");
 
     let mut env = jvm
         .attach_current_thread()
@@ -203,11 +267,17 @@ fn read_config_from_disk() -> Config {
         .join(current_exe.with_extension("json").file_name().unwrap());
 
     read_config(config_file_path).unwrap_or_else(|err| {
-        panic!("Failed to load config file {}: {}", current_exe.with_extension("json").to_string_lossy(), err);
+        panic!(
+            "Failed to load config file {}: {}",
+            current_exe.with_extension("json").to_string_lossy(),
+            err
+        );
     })
 }
 
 fn start_jvm_with_config(config: &Config) {
+    let application_working_directory =
+        env::current_dir().expect("Failed to get caller working directory");
     let cli_args: Vec<String> = env::args().skip(1).collect();
     let current_exe = env::current_exe().expect("Failed to get current exe location");
     let current_location = current_exe.parent().expect("Exe must be in a directory");
@@ -231,7 +301,11 @@ fn start_jvm_with_config(config: &Config) {
     let use_main_as_context_class_loader = config.useMainAsContextClassLoader.unwrap_or(false);
 
     start_jvm(
-        &runtime_location,
+        JvmDirectories {
+            runtime: &runtime_location,
+            bootstrap: current_location,
+            application: &application_working_directory,
+        },
         class_path,
         main_class,
         vm_args,
@@ -325,4 +399,102 @@ fn maybe_run_in_thread() {
 fn main() {
     env_logger::init();
     maybe_run_in_thread();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_vm_options, WorkingDirectoryGuard};
+    use std::{
+        env, fs,
+        path::{Path, PathBuf},
+        sync::Mutex,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    static WORKING_DIRECTORY_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn switches_to_launcher_for_bootstrap_and_restores_caller() {
+        let _lock = WORKING_DIRECTORY_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let fixture = WorkingDirectoryFixture::new();
+        env::set_current_dir(&fixture.caller).unwrap();
+
+        let mut guard = WorkingDirectoryGuard::enter(&fixture.launcher).unwrap();
+        assert_eq!(fixture.launcher, env::current_dir().unwrap());
+
+        guard.restore().unwrap();
+        assert_eq!(fixture.caller, env::current_dir().unwrap());
+    }
+
+    #[test]
+    fn restores_caller_when_jvm_bootstrap_unwinds() {
+        let _lock = WORKING_DIRECTORY_LOCK
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let fixture = WorkingDirectoryFixture::new();
+        env::set_current_dir(&fixture.caller).unwrap();
+
+        {
+            let _guard = WorkingDirectoryGuard::enter(&fixture.launcher).unwrap();
+            assert_eq!(fixture.launcher, env::current_dir().unwrap());
+        }
+
+        assert_eq!(fixture.caller, env::current_dir().unwrap());
+    }
+
+    #[test]
+    fn caller_user_dir_is_the_final_vm_option() {
+        let caller = Path::new("caller with spaces");
+        let options = build_vm_options(
+            &["/install/app/app.jar".to_string()],
+            &["-Duser.dir=/wrong".to_string(), "-Xmx1G".to_string()],
+            caller,
+            false,
+        );
+
+        assert_eq!(
+            Some("-Duser.dir=caller with spaces"),
+            options.last().map(String::as_str)
+        );
+    }
+
+    struct WorkingDirectoryFixture {
+        original: PathBuf,
+        root: PathBuf,
+        caller: PathBuf,
+        launcher: PathBuf,
+    }
+
+    impl WorkingDirectoryFixture {
+        fn new() -> Self {
+            let original = env::current_dir().unwrap();
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let root = env::temp_dir().join(format!("roast cwd {unique} ø"));
+            let caller = root.join("caller");
+            let launcher = root.join("launcher");
+            fs::create_dir_all(&caller).unwrap();
+            fs::create_dir_all(&launcher).unwrap();
+            let root = root.canonicalize().unwrap();
+            let caller = root.join("caller");
+            let launcher = root.join("launcher");
+            Self {
+                original,
+                root,
+                caller,
+                launcher,
+            }
+        }
+    }
+
+    impl Drop for WorkingDirectoryFixture {
+        fn drop(&mut self) {
+            env::set_current_dir(&self.original).unwrap();
+            fs::remove_dir_all(&self.root).unwrap();
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,11 @@
 #![cfg_attr(not(feature = "win_console"), windows_subsystem = "windows")]
+mod bootstrap;
+
+use bootstrap::{build_vm_options, WorkingDirectoryGuard};
 use jni::{objects::JString, InitArgsBuilder, JNIVersion, JavaVM};
 use serde::Deserialize;
 use std::{
-    env, fs, io,
+    env, fs,
     path::{Path, PathBuf},
 };
 
@@ -31,11 +34,6 @@ pub static NvOptimusEnablement: std::os::raw::c_ulong = 0x00000001;
 pub static AmdPowerXpressRequestHighPerformance: std::os::raw::c_int = 1;
 
 #[cfg(target_os = "windows")]
-static CLASS_PATH_DELIMITER: &str = ";";
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-static CLASS_PATH_DELIMITER: &str = ":";
-
-#[cfg(target_os = "windows")]
 const RUNTIME_LOCATION: [&str; 3] = ["runtime", "bin", "server"];
 #[cfg(all(target_os = "macos", not(feature = "macos_universal")))]
 const RUNTIME_LOCATION: [&str; 3] = ["runtime", "lib", "server"];
@@ -48,66 +46,10 @@ const RUNTIME_LOCATION: [&str; 3] = ["runtime", "lib", "server"];
 
 const APP_FOLDER: &str = "app";
 
-struct WorkingDirectoryGuard {
-    original: PathBuf,
-    restored: bool,
-}
-
 struct JvmDirectories<'a> {
     runtime: &'a Path,
     bootstrap: &'a Path,
     application: &'a Path,
-}
-
-impl WorkingDirectoryGuard {
-    fn enter(path: &Path) -> io::Result<Self> {
-        let original = env::current_dir()?;
-        env::set_current_dir(path)?;
-        Ok(Self {
-            original,
-            restored: false,
-        })
-    }
-
-    fn restore(&mut self) -> io::Result<()> {
-        if !self.restored {
-            env::set_current_dir(&self.original)?;
-            self.restored = true;
-        }
-        Ok(())
-    }
-}
-
-impl Drop for WorkingDirectoryGuard {
-    fn drop(&mut self) {
-        if !self.restored {
-            let _ = env::set_current_dir(&self.original);
-        }
-    }
-}
-
-fn build_vm_options(
-    class_path: &[String],
-    vm_args: &[String],
-    application_working_directory: &Path,
-    use_zgc_if_supported: bool,
-) -> Vec<String> {
-    let mut options = vec![format!(
-        "-Djava.class.path={}",
-        class_path.join(CLASS_PATH_DELIMITER)
-    )];
-    options.extend(vm_args.iter().cloned());
-
-    if use_zgc_if_supported && is_zgc_supported() {
-        options.push("-XX:+UnlockExperimentalVMOptions".to_string());
-        options.push("-XX:+UseZGC".to_string());
-    }
-
-    let user_dir = application_working_directory
-        .to_str()
-        .expect("Caller working directory must be valid Unicode");
-    options.push(format!("-Duser.dir={user_dir}"));
-    options
 }
 
 fn start_jvm(
@@ -238,19 +180,6 @@ fn start_jvm(
         env.exception_clear()
             .expect("Failed to clear the exception")
     }
-}
-
-#[cfg(target_os = "windows")]
-fn is_zgc_supported() -> bool {
-    // Windows 10 1803 is required for ZGC, see https://wiki.openjdk.java.net/display/zgc/Main#Main-SupportedPlatforms
-    // Windows 10 1803 is build 17134.
-    use windows_version::OsVersion;
-    return OsVersion::current() >= OsVersion::new(10, 0, 0, 17134);
-}
-
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-fn is_zgc_supported() -> bool {
-    return true;
 }
 
 fn read_config(path: PathBuf) -> Result<Config, Box<dyn std::error::Error>> {
@@ -399,102 +328,4 @@ fn maybe_run_in_thread() {
 fn main() {
     env_logger::init();
     maybe_run_in_thread();
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{build_vm_options, WorkingDirectoryGuard};
-    use std::{
-        env, fs,
-        path::{Path, PathBuf},
-        sync::Mutex,
-        time::{SystemTime, UNIX_EPOCH},
-    };
-
-    static WORKING_DIRECTORY_LOCK: Mutex<()> = Mutex::new(());
-
-    #[test]
-    fn switches_to_launcher_for_bootstrap_and_restores_caller() {
-        let _lock = WORKING_DIRECTORY_LOCK
-            .lock()
-            .unwrap_or_else(|error| error.into_inner());
-        let fixture = WorkingDirectoryFixture::new();
-        env::set_current_dir(&fixture.caller).unwrap();
-
-        let mut guard = WorkingDirectoryGuard::enter(&fixture.launcher).unwrap();
-        assert_eq!(fixture.launcher, env::current_dir().unwrap());
-
-        guard.restore().unwrap();
-        assert_eq!(fixture.caller, env::current_dir().unwrap());
-    }
-
-    #[test]
-    fn restores_caller_when_jvm_bootstrap_unwinds() {
-        let _lock = WORKING_DIRECTORY_LOCK
-            .lock()
-            .unwrap_or_else(|error| error.into_inner());
-        let fixture = WorkingDirectoryFixture::new();
-        env::set_current_dir(&fixture.caller).unwrap();
-
-        {
-            let _guard = WorkingDirectoryGuard::enter(&fixture.launcher).unwrap();
-            assert_eq!(fixture.launcher, env::current_dir().unwrap());
-        }
-
-        assert_eq!(fixture.caller, env::current_dir().unwrap());
-    }
-
-    #[test]
-    fn caller_user_dir_is_the_final_vm_option() {
-        let caller = Path::new("caller with spaces");
-        let options = build_vm_options(
-            &["/install/app/app.jar".to_string()],
-            &["-Duser.dir=/wrong".to_string(), "-Xmx1G".to_string()],
-            caller,
-            false,
-        );
-
-        assert_eq!(
-            Some("-Duser.dir=caller with spaces"),
-            options.last().map(String::as_str)
-        );
-    }
-
-    struct WorkingDirectoryFixture {
-        original: PathBuf,
-        root: PathBuf,
-        caller: PathBuf,
-        launcher: PathBuf,
-    }
-
-    impl WorkingDirectoryFixture {
-        fn new() -> Self {
-            let original = env::current_dir().unwrap();
-            let unique = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos();
-            let root = env::temp_dir().join(format!("roast cwd {unique} ø"));
-            let caller = root.join("caller");
-            let launcher = root.join("launcher");
-            fs::create_dir_all(&caller).unwrap();
-            fs::create_dir_all(&launcher).unwrap();
-            let root = root.canonicalize().unwrap();
-            let caller = root.join("caller");
-            let launcher = root.join("launcher");
-            Self {
-                original,
-                root,
-                caller,
-                launcher,
-            }
-        }
-    }
-
-    impl Drop for WorkingDirectoryFixture {
-        fn drop(&mut self) {
-            env::set_current_dir(&self.original).unwrap();
-            fs::remove_dir_all(&self.root).unwrap();
-        }
-    }
 }

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -1,0 +1,97 @@
+#[path = "../src/bootstrap.rs"]
+mod bootstrap;
+
+use bootstrap::{build_vm_options, WorkingDirectoryGuard};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    sync::Mutex,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+static WORKING_DIRECTORY_LOCK: Mutex<()> = Mutex::new(());
+
+#[test]
+fn switches_to_launcher_for_bootstrap_and_restores_caller() {
+    let _lock = WORKING_DIRECTORY_LOCK
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    let fixture = WorkingDirectoryFixture::new();
+    env::set_current_dir(&fixture.caller).unwrap();
+
+    let mut guard = WorkingDirectoryGuard::enter(&fixture.launcher).unwrap();
+    assert_eq!(fixture.launcher, env::current_dir().unwrap());
+
+    guard.restore().unwrap();
+    assert_eq!(fixture.caller, env::current_dir().unwrap());
+}
+
+#[test]
+fn restores_caller_when_jvm_bootstrap_unwinds() {
+    let _lock = WORKING_DIRECTORY_LOCK
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    let fixture = WorkingDirectoryFixture::new();
+    env::set_current_dir(&fixture.caller).unwrap();
+
+    {
+        let _guard = WorkingDirectoryGuard::enter(&fixture.launcher).unwrap();
+        assert_eq!(fixture.launcher, env::current_dir().unwrap());
+    }
+
+    assert_eq!(fixture.caller, env::current_dir().unwrap());
+}
+
+#[test]
+fn caller_user_dir_is_the_final_vm_option() {
+    let caller = Path::new("caller with spaces");
+    let options = build_vm_options(
+        &["/install/app/app.jar".to_string()],
+        &["-Duser.dir=/wrong".to_string(), "-Xmx1G".to_string()],
+        caller,
+        false,
+    );
+
+    assert_eq!(
+        Some("-Duser.dir=caller with spaces"),
+        options.last().map(String::as_str)
+    );
+}
+
+struct WorkingDirectoryFixture {
+    original: PathBuf,
+    root: PathBuf,
+    caller: PathBuf,
+    launcher: PathBuf,
+}
+
+impl WorkingDirectoryFixture {
+    fn new() -> Self {
+        let original = env::current_dir().unwrap();
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = env::temp_dir().join(format!("roast cwd {unique} ø"));
+        let caller = root.join("caller");
+        let launcher = root.join("launcher");
+        fs::create_dir_all(&caller).unwrap();
+        fs::create_dir_all(&launcher).unwrap();
+        let root = root.canonicalize().unwrap();
+        let caller = root.join("caller");
+        let launcher = root.join("launcher");
+        Self {
+            original,
+            root,
+            caller,
+            launcher,
+        }
+    }
+}
+
+impl Drop for WorkingDirectoryFixture {
+    fn drop(&mut self) {
+        env::set_current_dir(&self.original).unwrap();
+        fs::remove_dir_all(&self.root).unwrap();
+    }
+}

--- a/tests/launcher_working_directory.rs
+++ b/tests/launcher_working_directory.rs
@@ -1,0 +1,196 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+#[test]
+fn launches_jvm_from_install_and_restores_caller_directory() {
+    let fixture = LauncherFixture::new();
+    let output = Command::new(&fixture.launcher)
+        .current_dir(&fixture.caller)
+        .output()
+        .expect("failed to launch Roast fixture");
+
+    assert_success("Roast fixture", &output);
+    let user_dir = fs::read_to_string(fixture.caller.join("roast-user-dir.txt")).unwrap();
+
+    assert_eq!(fixture.caller, canonical_path(&user_dir));
+    assert_eq!(
+        "created by Java",
+        fs::read_to_string(fixture.caller.join("roast-relative-marker.txt")).unwrap()
+    );
+    assert_eq!(
+        "created by child",
+        fs::read_to_string(fixture.caller.join("roast-native-marker.txt"))
+            .unwrap()
+            .trim()
+    );
+    assert!(fixture.install.join("roast-bootstrap.log").is_file());
+    assert!(!fixture.caller.join("roast-bootstrap.log").exists());
+    assert!(!fixture.install.join("roast-relative-marker.txt").exists());
+    assert!(!fixture.install.join("roast-native-marker.txt").exists());
+}
+
+fn canonical_path(path: &str) -> PathBuf {
+    Path::new(path)
+        .canonicalize()
+        .unwrap_or_else(|error| panic!("failed to canonicalize {path:?}: {error}"))
+}
+
+fn assert_success(label: &str, output: &Output) {
+    assert!(
+        output.status.success(),
+        "{label} failed with {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+struct LauncherFixture {
+    original: PathBuf,
+    root: PathBuf,
+    install: PathBuf,
+    caller: PathBuf,
+    launcher: PathBuf,
+}
+
+impl LauncherFixture {
+    fn new() -> Self {
+        let original = env::current_dir().unwrap();
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = env::temp_dir().join(format!("roast launcher {unique} ø"));
+        let install = root.join("install");
+        let caller = root.join("caller");
+        let classes = install.join("app/classes");
+        fs::create_dir_all(&classes).unwrap();
+        fs::create_dir_all(&caller).unwrap();
+
+        let source = root.join("WorkingDirectoryProbe.java");
+        fs::write(&source, JAVA_PROBE).unwrap();
+        let javac = Command::new("javac")
+            .arg("-d")
+            .arg(&classes)
+            .arg(&source)
+            .output()
+            .expect("javac must be installed for the launcher integration test");
+        assert_success("javac", &javac);
+
+        let runtime = install.join(runtime_folder());
+        let jlink = Command::new("jlink")
+            .args(["--add-modules", "java.base", "--output"])
+            .arg(&runtime)
+            .output()
+            .expect("jlink must be installed for the launcher integration test");
+        assert_success("jlink", &jlink);
+
+        let launcher_name = if cfg!(target_os = "windows") {
+            "roast-cwd-probe.exe"
+        } else {
+            "roast-cwd-probe"
+        };
+        let launcher = install.join(launcher_name);
+        fs::copy(env!("CARGO_BIN_EXE_roast"), &launcher).unwrap();
+        make_executable(&launcher);
+
+        let config = install.join("app").join(
+            Path::new(launcher_name)
+                .with_extension("json")
+                .file_name()
+                .unwrap(),
+        );
+        fs::write(config, ROAST_CONFIG).unwrap();
+
+        let root = root.canonicalize().unwrap();
+        Self {
+            original,
+            install: root.join("install"),
+            caller: root.join("caller"),
+            launcher: root.join("install").join(launcher_name),
+            root,
+        }
+    }
+}
+
+impl Drop for LauncherFixture {
+    fn drop(&mut self) {
+        env::set_current_dir(&self.original).unwrap();
+        fs::remove_dir_all(&self.root).unwrap();
+    }
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+#[cfg(not(unix))]
+fn make_executable(_: &Path) {}
+
+#[cfg(all(
+    target_os = "macos",
+    feature = "macos_universal",
+    target_arch = "aarch64"
+))]
+fn runtime_folder() -> &'static str {
+    "runtime-aarch64"
+}
+
+#[cfg(all(
+    target_os = "macos",
+    feature = "macos_universal",
+    target_arch = "x86_64"
+))]
+fn runtime_folder() -> &'static str {
+    "runtime-x64"
+}
+
+#[cfg(any(
+    not(target_os = "macos"),
+    all(target_os = "macos", not(feature = "macos_universal"))
+))]
+fn runtime_folder() -> &'static str {
+    "runtime"
+}
+
+const ROAST_CONFIG: &str = r#"{
+  "classPath": ["app/classes"],
+  "mainClass": "WorkingDirectoryProbe",
+  "vmArgs": ["-Duser.dir=/wrong", "-Xlog:os=info:file=roast-bootstrap.log"],
+  "runOnFirstThread": true
+}"#;
+
+const JAVA_PROBE: &str = r#"
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class WorkingDirectoryProbe {
+    public static void main(String[] args) throws Exception {
+        boolean windows = System.getProperty("os.name").startsWith("Windows");
+        Process process = windows
+            ? new ProcessBuilder("cmd.exe", "/d", "/c", "echo created by child>roast-native-marker.txt").start()
+            : new ProcessBuilder("sh", "-c", "printf 'created by child' > roast-native-marker.txt").start();
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw new IllegalStateException("working-directory probe exited " + exitCode);
+        }
+
+        Files.writeString(
+            Path.of("roast-user-dir.txt"),
+            System.getProperty("user.dir"),
+            StandardCharsets.UTF_8
+        );
+        Files.writeString(Path.of("roast-relative-marker.txt"), "created by Java");
+    }
+}
+"#;


### PR DESCRIPTION
## Summary

- bootstrap HotSpot from the launcher directory, then restore the caller directory before loading application classes
- set `user.dir` to the caller directory as the final VM option so Java and native process semantics agree
- cover the real launcher/JVM boundary on Windows, macOS, and Linux with a generated jlink runtime
- run formatting and all-feature tests in the existing CI matrix

## Why

HotSpot validates relative classpath metadata used by AOT caches against the native working directory during JVM creation. Roast currently creates the JVM in the caller directory, so a cache trained in the packaged application layout can be rejected when the executable is launched elsewhere.

The working-directory switch is intentionally limited to `JavaVM::with_libjvm`. Roast restores the original directory before attaching JNI or loading the application main class. `-Duser.dir` is launcher-reserved and appended after configured VM arguments so Java code observes that same caller directory.

## Tests

- `cargo fmt --check`
- `cargo test --all-features`
- `cargo build --release`

The integration test copies the actual Roast binary into a Unicode fixture path, creates a minimal runtime with `jlink`, and launches it from a separate caller directory. It verifies:

- an initialization-time JVM log is created in the installation directory
- Java `user.dir` points to the caller directory
- a subprocess launched through `ProcessBuilder` inherits the caller directory
- Java relative file access resolves in the caller directory

A downstream consumer will separately verify strict JBR 25 AOT-cache loading and relocation with its production archive.
