### PR TITLE
Statically link and verify the MSVC runtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,15 @@ jobs:
           copy target/x86_64-pc-windows-msvc/release/roast.exe tmp_build/roast-win-no-gpu-x86_64.exe
           copy target/aarch64-pc-windows-msvc/release/roast.exe tmp_build/roast-win-no-gpu-aarch64.exe
           copy target/i686-pc-windows-msvc/release/roast.exe tmp_build/roast-win-no-gpu-i686.exe
+          $vswhere = "${env:ProgramFiles(x86)}/Microsoft Visual Studio/Installer/vswhere.exe"
+          $dumpbin = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find 'VC/Tools/MSVC/**/bin/Hostx64/x64/dumpbin.exe' | Select-Object -First 1
+          if (-not $dumpbin) { throw "dumpbin.exe not found" }
+          Get-ChildItem tmp_build/*.exe | ForEach-Object {
+            $imports = & $dumpbin /DEPENDENTS $_.FullName
+            if ($LASTEXITCODE -ne 0) { throw "dumpbin failed for $($_.Name)" }
+            $forbidden = $imports | Select-String -Pattern '(?i)\b(?:VCRUNTIME140(?:_1)?D?|MSVCP140(?:_\d+)?D?)\.dll\b'
+            if ($forbidden) { throw "$($_.Name) imports a redistributable MSVC runtime: $($forbidden.Line.Trim())" }
+          }
           Compress-Archive -Path tmp_build/roast-win-x86_64.exe -Destination out/roast-win-x86_64.exe.zip
           Compress-Archive -Path tmp_build/roast-win-aarch64.exe -Destination out/roast-win-aarch64.exe.zip
           Compress-Archive -Path tmp_build/roast-win-i686.exe -Destination out/roast-win-i686.exe.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
           Get-ChildItem tmp_build/*.exe | ForEach-Object {
             $imports = & $dumpbin /DEPENDENTS $_.FullName
             if ($LASTEXITCODE -ne 0) { throw "dumpbin failed for $($_.Name)" }
-            $forbidden = $imports | Select-String -Pattern '(?i)\b(?:VCRUNTIME140(?:_1)?D?|MSVCP140(?:_\d+)?D?)\.dll\b'
+            $forbidden = $imports | Select-String -Pattern '(?i)\b(?:VCRUNTIME|MSVCP)[A-Z0-9_]*\.dll\b'
             if ($forbidden) { throw "$($_.Name) imports a redistributable MSVC runtime: $($forbidden.Line.Trim())" }
           }
           Compress-Archive -Path tmp_build/roast-win-x86_64.exe -Destination out/roast-win-x86_64.exe.zip

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ log = "0.4.22"
 serde = { version = "1.0.190", features = ["derive"] }
 serde_json = "1.0.108"
 
+[build-dependencies]
+static_vcruntime = "2.0"
+
 [package.metadata.cross.target.x86_64-pc-windows-msvc]
 image = "ghcr.io/cross-rs/x86_64-pc-windows-msvc-cross:local"
 

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    static_vcruntime::metabuild();
     #[cfg(target_os = "windows")]
     enable_gpu_flags();
 }


### PR DESCRIPTION
## Summary

- statically link Roast's MSVC VCRuntime through `static_vcruntime`
- inspect all nine packaged Windows launcher variants and reject dynamic `VCRUNTIME*.dll` or `MSVCP*.dll` imports
- keep UCRT and Windows API-set dependencies unchanged

## Context

This reapplies the two behavioral hunks from #42 on current `main` without merging its stale v1.4-era branch. The implementation remains Daniele's original approach:

- `static_vcruntime = "2.0"` as a build dependency
- `static_vcruntime::metabuild()` in the existing build script

The additional CI assertion makes the self-contained-runtime contract executable across x86_64, aarch64, and i686 for the default, console, and no-GPU launchers.

This PR can supersede #42; I have not closed or modified the original PR.

## TDD evidence

The assertion was pushed first without the build hook. Fork CI run [29691051931](https://github.com/rock3r/roast/actions/runs/29691051931) failed on Windows after building all nine variants because `roast-win-aarch64.exe` imported `VCRUNTIME140.dll`.

After applying the static-link hook, run [29691340816](https://github.com/rock3r/roast/actions/runs/29691340816) passed on Windows, macOS, and Linux. The Windows leg rebuilt, inspected, and packaged all nine variants.

Local checks:

- `cargo test --all-features`
- `cargo build --release`
- `git diff --check`

`cargo fmt --check` has an existing failure in untouched `src/main.rs`; this PR does not change that file.
